### PR TITLE
wip: 백엔드에서 레벨 데이터를 가져오는 설정 추가

### DIFF
--- a/src/components/LevelLabel.jsx
+++ b/src/components/LevelLabel.jsx
@@ -1,23 +1,43 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
 const LevelLabel = () => {
+  const [level, setLevel] = useState(0); // 초기 레벨을 0으로 설정
+
+  useEffect(() => {
+    // 백엔드 엔드포인트에서 데이터 가져오기
+    fetch('https://your-backend-url.com/api/level') // 실제 URL로 변경
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json(); // 응답이 JSON 형식이어야 함
+      })
+      .then((data) => {
+        setLevel(data.level); // 응답에서 level 값을 추출하여 상태에 설정
+      })
+      .catch((error) => {
+        console.error('Error fetching level:', error); // 에러 로그 출력
+      });
+  }, []); // 컴포넌트가 처음 렌더링될 때만 실행
+
   return (
     <View style={styles.label}>
-      <Text style={styles.text}>Lv.01</Text>
+      {/* 레벨 표시 */}
+      <Text style={styles.text}>Lv.{level}</Text>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   label: {
-    position: 'absolute', // 필요한 위치에 고정
-    top: 270, // 조정 필요
-    right: 20, // 조정 필요
-    width: 50, // 적절한 너비
+    position: 'absolute',
+    top: 270,
+    right: 20,
+    width: 50,
     height: 22,
-    justifyContent: 'center', // 세로 정렬
-    alignItems: 'center', // 가로 정렬
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   text: {
     fontWeight: '400',


### PR DESCRIPTION
## ✨ **레벨 데이터 백엔드에서 가져오기 설정**

- 🧑‍💻 **백엔드 데이터 설정**: 레벨 데이터를 백엔드에서 가져오는 설정을 추가
- 🔧 **API 연결**: 백엔드 API로부터 레벨 정보를 가져오는 `fetch` 코드 추가
- 🎨 **UI 업데이트**: 레벨 데이터를 화면에 표시할 수 있도록 UI 수정

---

### 🔧 Changes

- **🆕 src/components/LevelLabel.jsx**: 백엔드에서 레벨 데이터를 가져오는 코드 추가

---

### ✅ Testing

- **🛠️ 로컬 테스트**: Expo Go에서 레벨 데이터를 가져오는 코드가 정상적으로 작동하는지 확인 예정
- **🔍 기능 확인**: 화면에 레벨 데이터가 정상적으로 표시되는지 확인은 아직 진행되지 않음

---