### PR TITLE
Feat: 프로필 카드 클릭 시 'MyScreen'으로 네비게이션 추가

### DIFF
--- a/src/components/ProfileCard.jsx
+++ b/src/components/ProfileCard.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet } from 'react-native';
+import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 
 export default function ProfileCard() {
+  const navigation = useNavigation(); // navigation 훅 초기화
   return (
-    <View style={styles.container}>
+    <TouchableOpacity
+      style={styles.container}
+      onPress={() => navigation.navigate('MyScreen')}
+    >
       <View style={styles.overlap}>
         <Text style={styles.textWrapper}>다귀찮을 띄</Text>
         <Text style={styles.subText} numberOfLines={1} ellipsizeMode="tail">
@@ -20,7 +25,7 @@ export default function ProfileCard() {
           style={styles.element}
         />
       </View>
-    </View>
+    </TouchableOpacity>
   );
 }
 


### PR DESCRIPTION
## ✨ 프로필 카드 클릭 시 'MyScreen'으로 네비게이션 추가
- 🧑‍💻 **프로필 카드 클릭 시 화면 전환**: `TouchableOpacity`를 사용하여 프로필 카드를 클릭할 때 `MyScreen`으로 네비게이션하는 기능 추가.
- 🚀 **`useNavigation` 훅 사용**: `react-navigation`의 `useNavigation` 훅을 사용하여 네비게이션을 처리하도록 변경.

---

### 🔧 Changes
- **🆕 `ProfileCard.jsx`**:
    - `TouchableOpacity`로 래핑하여 클릭 이벤트 처리 및 `MyScreen`으로 네비게이션 기능 추가.
    - `useNavigation` 훅을 사용하여 화면 전환 로직 구현.

---

### ✅ Testing
- **🛠️ 로컬 테스트**: Expo Go를 통해 프로필 카드를 클릭했을 때 `MyScreen`으로 정상적으로 이동하는지 확인.
- **🔍 기능 확인**: `TouchableOpacity` 클릭 시 네비게이션이 올바르게 동작하고 화면 전환이 정상적으로 이루어지는지 확인.

---
